### PR TITLE
bug/expander_same_capacity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: nickeldan/scrutiny:0.4.0
+      image: nickeldan/scrutiny:0.5.0
     steps:
       - uses: actions/checkout@v3
       - run: make tests

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ to uninstall.
 Testing
 =======
 
-Testing can be performed through the [Scrutiny framework](https://github.com/nickeldan/scrutiny).  After installing at least version 0.4.0 of the framework, you can run GEAR's tests by
+Testing can be performed through the [Scrutiny framework](https://github.com/nickeldan/scrutiny).  After installing at least version 0.5.0 of the framework, you can run GEAR's tests by
 
 ```sh
 make tests

--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+0.6.1:
+    - Fixed an endless loop when an expander returns the same capacity.
 
 0.6.0:
     - Added the gearLoad and gearPop functions.

--- a/include/gear/gear.h
+++ b/include/gear/gear.h
@@ -3,7 +3,7 @@
 
 #include <sys/types.h>
 
-#define GEAR_VERSION "0.6.0"
+#define GEAR_VERSION "0.6.1"
 
 enum gearRetValue {
     GEAR_RET_OK = 0,

--- a/src/gear.c
+++ b/src/gear.c
@@ -12,7 +12,7 @@ useExpander(gearExpander expander, size_t capacity, size_t new_length)
         size_t new_capacity;
 
         new_capacity = expander(capacity);
-        if (new_capacity < capacity) {
+        if (new_capacity <= capacity) {
             return 0;
         }
         capacity = new_capacity;

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -9,6 +9,13 @@ shortExpander(size_t capacity)
     return (capacity < 10) ? capacity + 2 : 0;
 }
 
+static size_t
+veryShortExpander(size_t capacity)
+{
+    (void)capacity;
+    return 1;
+}
+
 static void
 testInit(void)
 {
@@ -69,6 +76,12 @@ testExpander(void)
         SCR_ASSERT_EQ(gearAppend(&array, &num), GEAR_RET_OK);
     }
 
+    SCR_ASSERT_EQ(gearAppend(&array, &num), GEAR_RET_NO_EXPANSION);
+
+    gearReset(&array);
+
+    gearSetExpander(&array, veryShortExpander);
+    SCR_ASSERT_EQ(gearAppend(&array, &num), GEAR_RET_OK);
     SCR_ASSERT_EQ(gearAppend(&array, &num), GEAR_RET_NO_EXPANSION);
 
     gearReset(&array);
@@ -204,18 +217,16 @@ main()
 {
     scrGroup *group;
 
-    scrInit();
-
     group = scrGroupCreate(NULL, NULL);
-    scrGroupAddTest(group, "Initialize", testInit, 0, 0);
-    scrGroupAddTest(group, "Append", testAppend, 0, 0);
-    scrGroupAddTest(group, "Invalid expansion", testInvalidExpansion, 0, 0);
-    scrGroupAddTest(group, "Expander", testExpander, 0, 0);
-    scrGroupAddTest(group, "Iteration", testIteration, 0, 0);
-    scrGroupAddTest(group, "Iteration with index", testIterationWithIndex, 0, 0);
-    scrGroupAddTest(group, "Load", testLoad, 0, 0);
-    scrGroupAddTest(group, "Pop", testPop, 0, 0);
-    scrGroupAddTest(group, "Concatenate", testConcatenate, 0, 0);
+    scrGroupAddTest(group, "Initialize", testInit, 1, 0);
+    scrGroupAddTest(group, "Append", testAppend, 1, 0);
+    scrGroupAddTest(group, "Invalid expansion", testInvalidExpansion, 1, 0);
+    scrGroupAddTest(group, "Expander", testExpander, 1, 0);
+    scrGroupAddTest(group, "Iteration", testIteration, 1, 0);
+    scrGroupAddTest(group, "Iteration with index", testIterationWithIndex, 1, 0);
+    scrGroupAddTest(group, "Load", testLoad, 1, 0);
+    scrGroupAddTest(group, "Pop", testPop, 1, 0);
+    scrGroupAddTest(group, "Concatenate", testConcatenate, 1, 0);
 
     return scrRun(NULL, NULL);
 }


### PR DESCRIPTION
- Fixed an endless loop if the expander returns the same capacity.
- The testing now uses Scrutiny 0.5.0.